### PR TITLE
CI: Upgrade setuptools suite prior to installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ services:
   - docker
 language: python
 python:
-  - "3.6"
+  - "3.7"
+before_install:
+  - python3 -m pip install --upgrade pip setuptools wheel
 install:
   - pip3 install git+https://github.com/nextstrain/cli
   - nextstrain version

--- a/Snakefile
+++ b/Snakefile
@@ -145,7 +145,7 @@ rule ancestral:
         augur ancestral \
             --tree {input.tree} \
             --alignment {input.alignment} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
             --inference {params.inference}
         """
 
@@ -163,7 +163,7 @@ rule translate:
             --tree {input.tree} \
             --ancestral-sequences {input.node_data} \
             --reference-sequence {input.reference} \
-            --output {output.node_data}
+            --output-node-data {output.node_data}
         """
 
 rule traits:
@@ -180,7 +180,7 @@ rule traits:
         augur traits \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
             --columns {params.columns} \
             --confidence
         """
@@ -201,7 +201,7 @@ rule export:
         auspice_meta = "auspice/lassa_{segment}_meta.json"
     shell:
         """
-        augur export \
+        augur export v1 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \


### PR DESCRIPTION
### Description of proposed changes   

Follows recommended practice for new Python installations to ensure that
pip, setuptools, and wheel are always upgraded [1] regardless of the
system-wide Python version. Also, follows our internal standard to use
the oldest supported Python version in CI when we do not use a matrix of
all supported versions, to best catch possible issues with older
versions.

[1] https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date