### PR TITLE
Add host annotation to tips of the phylogenetic tree

### DIFF
--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -26,6 +26,11 @@
       "key": "country",
       "title": "Country",
       "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -36,7 +41,8 @@
   ],
   "filters": [
     "country",
-    "author"
+    "author",
+    "host"
   ],
   "metadata_columns": [
     "genbank_accession"

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -18,7 +18,7 @@
       "type": "continuous"
     },
     {
-      "key": "author",
+      "key": "abbr_authors",
       "title": "Author",
       "type": "categorical"
     },
@@ -41,7 +41,7 @@
   ],
   "filters": [
     "country",
-    "author",
+    "abbr_authors",
     "host"
   ],
   "metadata_columns": [

--- a/phylogenetic/defaults/color_orderings.tsv
+++ b/phylogenetic/defaults/color_orderings.tsv
@@ -233,3 +233,17 @@ recency	1-2 days ago
 recency	New
 
 ################
+
+host	Homo sapiens
+host	Canis lupus familiaris
+host	Capra hircus
+host	Cavia porcellus
+host	Rodentia
+host	Mus baoulei
+host	Rattus norvegicus
+host	Hylomyscus pamfi
+host	Lophuromys sikapusi
+host	Mastomys sp.
+host	Mastomys
+host	Mastomys erythroleucus
+host	Mastomys natalensis


### PR DESCRIPTION
## Description of proposed changes

From meeting a few people familiar with lassa research, it seems to be common practice to look at host dynamics especially between `Homo sapians` and `Mastomys natalensis`. Ergo, add host annotations to the tree. 

While adding the host annotation, also fixed the `author` annotation to show abbreviated authors (e.g. "lastname, et al.") instead of a long author list.

Host annotation can be seen here: https://next.nextstrain.org/staging/lassa/l?c=host

I realize there is some [discussion](https://bedfordlab.slack.com/archives/CFEU0GNNS/p1722901146840109) on a "host taxonomy" for other pathogen builds, which may affect this later.

## Related issue(s)

## Checklist

- [ ] Checks pass

