### PR TITLE
Add logs and benchmarks

### DIFF
--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -38,6 +38,10 @@ rule ancestral:
         alignment = "results/{segment}/aligned.fasta",
     output:
         node_data = "results/{segment}/nt_muts.json"
+    log:
+        "logs/{segment}/ancestral.txt",
+    benchmark:
+        "benchmarks/{segment}/ancestral.txt"
     params:
         inference = "joint"
     shell:
@@ -46,7 +50,8 @@ rule ancestral:
             --tree {input.tree} \
             --alignment {input.alignment} \
             --output-node-data {output.node_data} \
-            --inference {params.inference}
+            --inference {params.inference} \
+            2>&1 | tee {log}
         """
 
 rule translate:
@@ -57,13 +62,18 @@ rule translate:
         reference = "defaults/lassa_{segment}.gb"
     output:
         node_data = "results/{segment}/aa_muts.json"
+    log:
+        "logs/{segment}/translate.txt",
+    benchmark:
+        "benchmarks/{segment}/translate.txt"
     shell:
         """
         augur translate \
             --tree {input.tree} \
             --ancestral-sequences {input.node_data} \
             --reference-sequence {input.reference} \
-            --output-node-data {output.node_data}
+            --output-node-data {output.node_data} \
+            2>&1 | tee {log}
         """
 
 rule traits:
@@ -73,6 +83,10 @@ rule traits:
         metadata = "data/{segment}/metadata.tsv",
     output:
         node_data = "results/{segment}/traits.json",
+    log:
+        "logs/{segment}/traits.txt",
+    benchmark:
+        "benchmarks/{segment}/traits.txt"
     params:
         strain_id_field = config["strain_id_field"],
         columns = config['traits']['columns']
@@ -84,5 +98,6 @@ rule traits:
             --metadata-id-columns {params.strain_id_field} \
             --output-node-data {output.node_data} \
             --columns {params.columns} \
-            --confidence
+            --confidence \
+            2>&1 | tee {log}
         """

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -25,6 +25,10 @@ rule tree:
         alignment = "results/{segment}/aligned.fasta"
     output:
         tree = "results/{segment}/tree_raw.nwk"
+    log:
+        "logs/{segment}/tree.txt",
+    benchmark:
+        "benchmarks/{segment}/tree.txt"
     params:
         method = "iqtree"
     shell:
@@ -32,7 +36,8 @@ rule tree:
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
-            --method {params.method}
+            --method {params.method} \
+            2>&1 | tee {log}
         """
 
 rule refine:
@@ -50,6 +55,10 @@ rule refine:
     output:
         tree = "results/{segment}/tree.nwk",
         node_data = "results/{segment}/branch_lengths.json"
+    log:
+        "logs/{segment}/refine.txt",
+    benchmark:
+        "benchmarks/{segment}/refine.txt"
     params:
         strain_id_field = config["strain_id_field"],
         coalescent = config['refine']['coalescent'],
@@ -70,5 +79,6 @@ rule refine:
             --clock-rate {params.clock_rate} \
             --date-confidence \
             --date-inference {params.date_inference} \
-            --root {params.root}
+            --root {params.root} \
+            2>&1 | tee {log}
         """

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -32,13 +32,18 @@ rule colors:
         metadata = "data/{segment}/metadata.tsv",
     output:
         colors = "results/{segment}/colors.tsv"
+    log:
+        "logs/{segment}/colors.txt",
+    benchmark:
+        "benchmarks/{segment}/colors.txt"
     shell:
         """
         python3 scripts/assign-colors.py \
             --color-schemes {input.color_schemes} \
             --ordering {input.color_orderings} \
             --metadata {input.metadata} \
-            --output {output.colors}
+            --output {output.colors} \
+            2>&1 | tee {log}
         """
 
 rule export:
@@ -55,6 +60,10 @@ rule export:
         auspice_config = config['export']['auspice_config'],
     output:
         auspice = "results/{segment}/lassa.json",
+    log:
+        "logs/{segment}/export.txt",
+    benchmark:
+        "benchmarks/{segment}/export.txt"
     params:
         strain_id_field = config["strain_id_field"],
     shell:
@@ -68,7 +77,8 @@ rule export:
             --description {input.description} \
             --auspice-config {input.auspice_config} \
             --output {output.auspice} \
-            --include-root-sequence-inline
+            --include-root-sequence-inline \
+            2>&1 | tee {log}
         """
 
 rule final_strain_name:
@@ -77,6 +87,10 @@ rule final_strain_name:
         metadata="data/{segment}/metadata.tsv",
     output:
         auspice_json="auspice/lassa_{segment}.json",
+    log:
+        "logs/{segment}/final_strain_name.txt",
+    benchmark:
+        "benchmarks/{segment}/final_strain_name.txt"
     params:
         strain_id_field=config["strain_id_field"],
         display_strain_field=config["display_strain_field"],
@@ -87,5 +101,6 @@ rule final_strain_name:
             --metadata-id-columns {params.strain_id_field} \
             --input-auspice-json {input.auspice_json} \
             --display-strain-name {params.display_strain_field} \
-            --output {output.auspice_json}
+            --output {output.auspice_json} \
+            2>&1 | tee {log}
         """

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -62,6 +62,10 @@ rule filter:
         exclude = config['filter']['exclude']
     output:
         sequences = "results/{segment}/filtered.fasta"
+    log:
+        "logs/{segment}/filter.txt",
+    benchmark:
+        "benchmarks/{segment}/filter.txt"
     params:
         strain_id_field = config["strain_id_field"],
         min_length = config['filter']['min_length'],
@@ -78,7 +82,8 @@ rule filter:
             --min-length {params.min_length} \
             --query "{params.query}" \
             --output {output.sequences} \
-            {params.custom_params}
+            {params.custom_params} \
+            2>&1 | tee {log}
         """
 
 rule align:
@@ -91,6 +96,10 @@ rule align:
         reference = "defaults/lassa_{segment}.gb"
     output:
         alignment = "results/{segment}/aligned.fasta"
+    log:
+        "logs/{segment}/align.txt",
+    benchmark:
+        "benchmarks/{segment}/align.txt"
     shell:
         """
         augur align \
@@ -98,5 +107,6 @@ rule align:
             --reference-sequence {input.reference} \
             --output {output.alignment} \
             --fill-gaps \
-            --remove-reference
+            --remove-reference \
+            2>&1 | tee {log}
         """


### PR DESCRIPTION
## Description of proposed changes

Logs and benchmark metrics can be useful for debugging and measuring which rules are taking the most time to run. This also follows more closely to our Nextstrain Best Practices

* https://docs.nextstrain.org/en/latest/reference/snakemake-style-guide.html#log-standard-out-and-error-output-to-log-files-and-the-terminal

## Related issue(s)

* Addresses https://github.com/nextstrain/lassa/issues/26

## Checklist

- [x] Checks pass
