### PR TITLE
Include updated description for page footer

### DIFF
--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -1,14 +1,26 @@
 We gratefully acknowledge the authors, originating and submitting laboratories of the genetic sequences and metadata for sharing their work. Please note that although data generators have generously shared data in an open fashion, that does not mean there should be free license to publish on this data. Data generators should be cited where possible and collaborations should be sought in some circumstances. Please try to avoid scooping someone else's work. Reach out if uncertain.
 
-This work is made possible by the open sharing of genetic data by research groups, including these groups currently collecting Lassa sequences: [Christian Happi](http://acegid.org/), [Pardis Sabeti](https://www.sabetilab.org/), [Katherine Siddle](https://www.sabetilab.org/katherine-siddle/) and colleagues, whose data was shared via [this virological.org post](http://virological.org/t/new-lassa-virus-genomes-from-nigeria-2015-2016/191). If you intend to use these sequences prior to publication, please contact them directly to coordinate.
+Much of the genomic data here comes from publications [Andersen et al 2015](https://doi.org/10.1016/j.cell.2015.07.020), [Siddle et al 2018](https://doi.org/10.1056/NEJMoa1804498
+) and [Kafetzopoulou et al 2019](https://doi.org/10.1126/science.aau9343), but with more recent sequences from NCBI may not yet be published.
 
-The Irrua Specialist Teaching Hospital (ISTH) and Institute for Lassa Fever Research and Control (ILFRC), Irrua, Edo State, Nigeria; The Bernhard-Nocht Institute for Tropical Medicine (BNITM), Hamburg, Germany; Public Health England (PHE); African Center of Excellence for Genomics of Infectious Disease (ACEGID), Redeemer’s University, Ede, Nigeria; Broad Institute of MIT and Harvard University, Cambridge, MA, USA. For further details, including conditions of reuse, please contact [Ephraim Epogbaini](mailto:epogbaini@yahoo.com), [Stephan Günther](http://www.who.int/blueprint/about/stephan-gunther/en/), and [Philippe Lemey](https://rega.kuleuven.be/cev/ecv/lab-members/PhilippeLemey.html). Their data was first shared via [this virological.org post](http://virological.org/t/2018-lasv-sequencing-continued/192/8), which is continually updated.
+We maintain two views of Lassa virus evolution: one showing evolution of the [L segment](https://nextstrain.org/lassa/l) and the other showing evolution of the [S segment](https://nextstrain.org/lassa/s). A tangle tree showing [co-evolution of L and S](https://nextstrain.org/lassa/l:lassa/s) is also available.
+
+#### Underlying data
 
 We curate sequence data and metadata from NCBI as the starting point for our analyses. Curated sequences and metadata are available as flat files at:
 
+##### L segment
 * [data.nextstrain.org/files/workflows/lassa/l/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/lassa/l/sequences.fasta.zst)
 * [data.nextstrain.org/files/workflows/lassa/l/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/lassa/l/metadata.tsv.zst)
+
+##### S segment
 * [data.nextstrain.org/files/workflows/lassa/s/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/lassa/s/sequences.fasta.zst)
 * [data.nextstrain.org/files/workflows/lassa/s/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/lassa/s/metadata.tsv.zst)
+
+##### Both segments combined
 * [data.nextstrain.org/files/workflows/lassa/all/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/lassa/all/sequences.fasta.zst)
 * [data.nextstrain.org/files/workflows/lassa/all/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/lassa/all/metadata.tsv.zst)
+
+---
+
+Screenshots may be used under a [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/) and attribution to nextstrain.org must be provided.


### PR DESCRIPTION
The existing text was keyed to the time period in 2018 when recent Lassa data had been shared but not yet published. I replaced this text with just links to relevant publications. I also added links to L, S and tangle tree, as well as the standard simple screenshot disclaimer.
