### PR TITLE
Push live build on to nextstrain.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # nextstrain.org/lassa
 
-_Currently, this pathogen build is in draft state. Recent outputs are visible at [nextstrain.org/staging/lassa/l](https://nextstrain.org/staging/lassa/l) and [nextstrain.org/staging/lassa/s](https://nextstrain.org/staging/lassa/s), but it's not yet fully QCed or automated._
-
 This repository contains two workflows for the analysis of Lassa virus data:
 
 - [`ingest/`](./ingest) - Download data from GenBank, clean and curate it, separate into L and S segments, and upload it to S3

--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,4 +1,4 @@
 custom_rules:
   - build-configs/nextstrain-automation/deploy.smk
 
-deploy_url: "s3://nextstrain-staging"
+deploy_url: "s3://nextstrain-data"


### PR DESCRIPTION
## Description of proposed changes

This PR pushes lassa build to nextstrain.org by reverting commit 81d1cd1f4e86de422c549b2c54a11bada0c775a5.

## Related issue(s)

* Addresses: https://github.com/nextstrain/lassa/issues/14
* Related to: https://github.com/nextstrain/lassa/issues/32

## Checklist

- [x] Checks pass
