### PR TITLE
Improved Segment Length Filtering

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -13,7 +13,9 @@ strain_id_field: "accession"
 display_strain_field: "strain"
 
 filter:
-  min_length: 500
+  min_length:
+    l: 5000
+    s: 2000
   include: "defaults/include.txt" # need to always include root strains
   exclude: "defaults/exclude.txt"
   query: "is_lab_host != 'true'"

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -68,7 +68,7 @@ rule filter:
         "benchmarks/{segment}/filter.txt"
     params:
         strain_id_field = config["strain_id_field"],
-        min_length = config['filter']['min_length'],
+        min_length = lambda wildcards: config['filter']['min_length'][wildcards.segment],
         query = config['filter']['query'],
         custom_params = config['filter']['custom_params'],
     shell:


### PR DESCRIPTION
## Description of proposed changes

We've updated the minimum length requirements for segment builds to address issues with short sequences causing strange long branched outliers in the phylogenetic tree. The previous default of 500nt seemed insufficient. New segment-specific filters have been implemented:

### L Gene
- Original length: ~7,000 nucleotides
- New minimum length filter: 5,000 nucleotides

### S Gene
- Original length: ~3,000 nucleotides
- New minimum length filter: 2,000 nucleotides

These adjustments should result in more robust and accurate phylogenetic analyses by excluding potentially problematic short sequences.

## Related issue(s)

* https://github.com/nextstrain/lassa/issues/36

## Checklist

- [x] Checks pass

