### PR TITLE
Instead of "fixed" root, use mid_point rooting

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -31,7 +31,6 @@ tree:
 refine:
   coalescent: "opt"
   date_inference: "marginal"
-  clock_rate: 0.0006
   # Root the tree based on "mid_point" for treetime
   root:
     l: "mid_point"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -32,14 +32,11 @@ refine:
   coalescent: "opt"
   date_inference: "marginal"
   clock_rate: 0.0006
-  # Rooting to outgroup clade based on strains
-  # Pinneo-NIG-1969 (L accession KM822127 and S accession KM822128)
-  # and strain 812285 (L accession MG812674 and S accession MG812675)
-  # TreeTime needs two tips to root to common ancestor of these tips
+  # Root the tree based on "mid_point" for treetime
   root:
-    l: "KM822127 MG812674"
-    s: "KM822128 MG812675"
-    gpc: "KM822128"
+    l: "mid_point"
+    s: "mid_point"
+    gpc: "mid_point"
 
 ancestral:
   inference: "joint"

--- a/phylogenetic/defaults/exclude.txt
+++ b/phylogenetic/defaults/exclude.txt
@@ -6,3 +6,10 @@ KU978809 # GUINEA_Z_185a L segment
 KU978810 # GUINEA_Z_185a S segment
 KU978811 # NIGERIA_IKEJI S segment
 KU978812 # NIGERIA_IKEJI L segment
+OR493499 # Large insertion off the end of the S segment
+OR493501 # Large insertion off the end of the S segment
+OR493502 # Large insertion off the end of the S segment
+OR493503 # Large insertion off the end of the S segment
+OR493504 # Large insertion off the end of the S segment
+OM735982 # Large insertion of Ns in the S segment
+MK117995 # 6 base insersion in the S segment

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -63,7 +63,6 @@ rule refine:
         strain_id_field = config["strain_id_field"],
         coalescent = config['refine']['coalescent'],
         date_inference = config['refine']['date_inference'],
-        clock_rate = config['refine']['clock_rate'],
         root = lambda wildcards: config['refine']['root'][wildcards.segment],
     shell:
         """
@@ -76,7 +75,6 @@ rule refine:
             --output-node-data {output.node_data} \
             --timetree \
             --coalescent {params.coalescent} \
-            --clock-rate {params.clock_rate} \
             --date-confidence \
             --date-inference {params.date_inference} \
             --root {params.root} \


### PR DESCRIPTION
## Description of proposed changes

This draft PR differs in that it is mostly formatted as a continuation of an ongoing discussion about fixed root versus allowing TreeTime to infer the root of Lassa virus phylogenetic trees. The discussion was initially started by @JoiRichi and @j23414 but is open to input from other contributors. This PR acts as a documented code exploration of the topics discussed, providing a practical examination of the concepts and ideas raised during the conversation.

|build | Compare Before (left) and After (right) | before clock rate (6e-4) | after clock rate (let treetime estimate) |
|:--|:--| :--| :--|
| l | https://next.nextstrain.org/lassa/l:staging/lassa/trials/rerooting/lassa/l | [1.55e-3](https://next.nextstrain.org/lassa/l?l=clock) | [5.21e-7](https://next.nextstrain.org/staging/lassa/trials/rerooting/lassa/l?l=clock) |
| s | https://next.nextstrain.org/lassa/s:staging/lassa/trials/rerooting/lassa/s | [1.29e-3](https://next.nextstrain.org/lassa/l?l=clock) | [1.25e-5](https://next.nextstrain.org/staging/lassa/trials/rerooting/lassa/s?l=clock) |

## Related issue(s)

* https://github.com/nextstrain/lassa/issues/44

## Checklist

- [x] Checks pass

