### PR TITLE
Exported case annotation

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -4,7 +4,9 @@
 # If there are multiple annotations for the same id and field, then the last value is used
 # Lines starting with '#' are treated as comments
 # Any '#' after the field value are treated as comments.
-LT601601	country	Togo # Alzey strain, described in https://journals.asm.org/doi/full/10.1128/genomea.00938-16
-LT601602	country	Togo # Acquired by funeral worker, but decreased was evacuated from Togo
-LT601601	region	Africa
-LT601602	region	Africa
+
+# These are proposed to be left as Germany to show local transmission
+LT601601	country	Germany # Alzey strain, described in https://journals.asm.org/doi/full/10.1128/genomea.00938-16 (L seg)
+LT601602	country	Germany # Acquired by funeral worker, but decreased was evacuated from Togo.(S Seg)
+LT601601	region	Europe
+LT601602	region	Europe


### PR DESCRIPTION
This PR suggests annotation for the exported Lassa fever case from Togo to Germany in 2016, which resulted in local (secondary) transmission.

This represents the first documented case of local transmission of Lassa fever outside of West Africa. A mortician in Germany developed symptoms after handling the body of the index case.
See: [Wolff et al., 2016 – Genome Announcements](https://journals.asm.org/doi/full/10.1128/genomea.00938-16)

This PR also opens a discussion on how best to annotate exported cases with local transmission on our live trees.