### PR TITLE
Nextclade: Update min-seed-cover from sweeps

### DIFF
--- a/nextclade_data/gpc/pathogen.json
+++ b/nextclade_data/gpc/pathogen.json
@@ -24,7 +24,7 @@
     "scoreMatch": 5,
     "retryReverseComplement": true,
     "allowedMismatches": 10,
-    "minSeedCover": 0.01,
+    "minSeedCover": 0.16,
     "minLength": 800
   },
   "qc": {

--- a/nextclade_data/l/pathogen.json
+++ b/nextclade_data/l/pathogen.json
@@ -24,7 +24,7 @@
     "scoreMatch": 5,
     "retryReverseComplement": true,
     "allowedMismatches": 10,
-    "minSeedCover": 0.01,
+    "minSeedCover": 0.12,
     "minLength": 800
   },
   "qc": {


### PR DESCRIPTION
## Description of proposed changes

Updated derived min-seed-cover threshold values from sweeps

* [seedcover_sweep_plotly.py](https://github.com/nextstrain/lassa/blob/11711930b77d32df8763a4964406b40dcc96cdc4/nextclade/seedcover_sweep_plotly.py#L31C1-L36C36)

Script allows reproducible inference of parameters.

* L: https://github.com/nextstrain/lassa/blob/main/nextclade/l_segment_sweep/summary.txt
* GPC: https://github.com/nextstrain/lassa/blob/main/nextclade/gpc_segment_sweep/summary.txt

## Related issue(s)


## Checklist


- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
